### PR TITLE
Use var instead of const

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-const charsets = require('password-sheriff').charsets;
+var charsets = require("password-sheriff").charsets;
 
-const upperCase = charsets.upperCase;
-const lowerCase = charsets.lowerCase;
-const numbers = charsets.numbers;
-const specialCharacters = charsets.specialCharacters;
+var upperCase = charsets.upperCase;
+var lowerCase = charsets.lowerCase;
+var numbers = charsets.numbers;
+var specialCharacters = charsets.specialCharacters;
 
-const policies = {
+var policies = {
   none: {
     length: { minLength: 1 }
   },


### PR DESCRIPTION
UglifyJS is choking our webpack build because it encounters a `const` token in this library. Adding a build step such as babel seemed overly complicated for this lib, so I opted to just use `var` here.

here is the error output from our webpack build:
```
ERROR in vendors~Auth0Lock.f058c77f.chunk.js from UglifyJs
Unexpected token: keyword (const) [../node_modules/auth0-password-policies/index.js:1,0][vendors~Auth0Lock.f058c77f.chunk.js:17865,0]
```